### PR TITLE
index: Fix link to Quick Start guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 						<p class="first-paragraph">Describe how to deploy your application in JavaScript. Deploy to the cloud with one command.</p>
 						<p class="second-paragraph">
 						Kelda, formerly Quilt, provides an open source JavaScript framework that lets you share and reuse infrastructure expertise using an intuitive API.  We take care of all the tedious, low-level details, and make sure that your application runs smoothly and stays healthy - regardless of which cloud you're on.</p>
-						<a href="http://docs.kelda.io/#getting-started"><button class="btn btn-red btn-started">GET STARTED</button></a>
+						<a href="http://docs.kelda.io/#quick-start"><button class="btn btn-red btn-started">GET STARTED</button></a>
 					</div>
 					<div class="col-md-6 padding-xs-0">
 						<div class="mac">
@@ -308,7 +308,7 @@
 					<div class="col-sm-4">
 						<img src="assets/icons/icon-file.png" class="max-height-65">
 						<h4>Check out a tutorial</h4>
-						<a href="http://docs.kelda.io/#getting-started"><button class="btn btn-red">GET STARTED</button></a>
+						<a href="http://docs.kelda.io/#quick-start"><button class="btn btn-red">GET STARTED</button></a>
 					</div>
 					<div class="col-sm-4">
 						<img src="assets/icons/icon-slack.png" class="max-height-65">


### PR DESCRIPTION
An upcoming change to the docs will rename the Getting Started section to
Quick Start, so the url will change as well.