### PR TITLE
navbar: Make the background white

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,17 +14,17 @@ function atTop() {
   }
 }
 
-// function brightenHeader() {
-//   if (atTop()) {
-//     $('#header').removeClass('light');
-//   } else {
-//     $('#header').addClass('light');
-//   }
-// }
-//
-// brightenHeader();
-//
-// $(window).on('scroll', brightenHeader);
+function brightenHeader() {
+  if (atTop()) {
+    $('#header').removeClass('light');
+  } else {
+    $('#header').addClass('light');
+  }
+}
+
+brightenHeader();
+
+$(window).on('scroll', brightenHeader);
 
 // homepage code
 if ($('.landing').length) {


### PR DESCRIPTION
Before, the navbar was transparent, so it would overlap with the content
of the site after the user scrolls. This commit makes it so that the
background becomes white on scroll.

# Before: 
<img width="719" alt="screen shot 2018-04-24 at 5 46 16 pm" src="https://user-images.githubusercontent.com/10263364/39220684-7aafa1fc-47e7-11e8-8655-879407f95f79.png">

# After:
<img width="715" alt="screen shot 2018-04-24 at 5 45 59 pm" src="https://user-images.githubusercontent.com/10263364/39220683-79478122-47e7-11e8-8ca4-2f56444ea90d.png">

